### PR TITLE
feat: implement slack slash commands api

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources"]
 
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
-        com.github.parenthesin/components {:mvn/version "0.4.2"
+        com.github.parenthesin/components {:mvn/version "0.4.3"
                                            :exclusions  [metosin/malli]}
         aero/aero {:mvn/version "1.1.6"}
         com.github.seancorfield/honeysql {:mvn/version "2.6.1281"}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,5 +1,6 @@
 {:webserver/port #long #or [#env PORT 3001]
  :discord {:app-public-key #or [#env DISCORD_PUBLIC_KEY ""]}
+ :slack {:signing-secret #or [#env SLACK_SIGNING_SECRET ""]}
  :telegram {:bot-token #or [#env TELEGRAM_BOT_TOKEN ""]}
  :database {:dbtype "postgres"
             :dbname #or [#env DB-NAME #env DB_NAME "postgres"]

--- a/scripts/slack-manifest.yaml
+++ b/scripts/slack-manifest.yaml
@@ -1,0 +1,29 @@
+display_information:
+  name: Super Dice Roll
+settings:
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  is_hosted: false
+  token_rotation_enabled: false
+features:
+  app_home:
+    home_tab_enabled: true
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
+  bot_user:
+    display_name: Super Dice Roll
+  slash_commands:
+    - command: /roll
+      description: <NDM> N = Number of dices D = Type of dices (D6, D12, D20) M = Modifiers (+1, -3)
+      usage_hint: /roll 3D6+3
+      url: https://super-dice-roll-clj.fly.dev/slack/slash/roll
+    - command: /history
+      description: Lists your lasts 10 rolls with the results.
+      url: https://super-dice-roll-clj.fly.dev/slack/slash/history
+    - command: /help
+      description: Get help about using this bot `help`.
+      url: https://super-dice-roll-clj.fly.dev/slack/slash/history
+oauth_config:
+  scopes:
+    bot:
+      - commands

--- a/src/super_dice_roll/adapters.clj
+++ b/src/super_dice_roll/adapters.clj
@@ -56,6 +56,9 @@
        :discord (str "*{{username}} rolled {{command}}*\n"
                      "`[{{each}}]{{modifier}}`\n"
                      "**total: {{total}}**\n")
+       :slack (str "*{{username}} rolled {{command}}*\n"
+                   "`[{{each}}]{{modifier}}`\n"
+                   "**total: {{total}}**\n")
        :telegram (str "<i>{{username}} rolled {{command}}</i>\n"
                       "<pre>[{{each}}]{{modifier}}</pre>\n"
                       "<b>total: {{total}}</b>\n"))
@@ -72,6 +75,8 @@
      (case channel
        :discord (str "{{username}} the command *{{command}}* is invalid\n"
                      "{{help|safe}}")
+       :slack (str "{{username}} the command *{{command}}* is invalid\n"
+                   "{{help|safe}}")
        :telegram (str "{{username}} the command <i>{{command}}</i> is invalid\n"
                       "{{help|safe}}"))
      {:username (->name username nick)
@@ -85,6 +90,7 @@
     (selmer/render
      (case channel
        :discord "`{{command}}: [{{each}}]{{modifier}} = {{total}}`\n"
+       :slack "`{{command}}: [{{each}}]{{modifier}} = {{total}}`\n"
        :telegram "<pre>{{command}}: [{{each}}]{{modifier}} = {{total}}</pre>\n")
      {:command command
       :each (string/join "," each)
@@ -98,6 +104,8 @@
      (case channel
        :discord (str "*{{username}} history*\n"
                      "{{history|safe}}")
+       :slack (str "*{{username}} history*\n"
+                   "{{history|safe}}")
        :telegram (str "<i>{{username}} history</i>\n"
                       "{{history|safe}}"))
      {:username (->name username nick)

--- a/src/super_dice_roll/adapters/bytes.clj
+++ b/src/super_dice_roll/adapters/bytes.clj
@@ -1,0 +1,20 @@
+(ns super-dice-roll.adapters.bytes
+  (:require [clojure.string :as str]))
+
+(defn bytes->hex
+  "convert byte array to hex string."
+  [^bytes byte-array]
+  (let [hex [\0 \1 \2 \3 \4 \5 \6 \7 \8 \9 \a \b \c \d \e \f]]
+    (letfn [(hexify-byte [b]
+              (let [v (bit-and b 0xFF)]
+                [(hex (bit-shift-right v 4)) (hex (bit-and v 0x0F))]))]
+      (str/join (mapcat hexify-byte byte-array)))))
+
+(defn hex->bytes
+  "convert hex string to byte array."
+  [^String hex-string]
+  (letfn [(unhexify-2 [^Character c1 ^Character c2]
+            (unchecked-byte
+             (+ (bit-shift-left (Character/digit c1 16) 4)
+                (Character/digit c2 16))))]
+    (byte-array (map #(apply unhexify-2 %) (partition 2 hex-string)))))

--- a/src/super_dice_roll/discord/security.clj
+++ b/src/super_dice_roll/discord/security.clj
@@ -1,27 +1,9 @@
 (ns super-dice-roll.discord.security
-  (:require [clojure.string :as str])
+  (:require [super-dice-roll.adapters.bytes :as adapters.bytes])
   (:import (java.security SecureRandom)
            (org.bouncycastle.crypto.generators Ed25519KeyPairGenerator)
            (org.bouncycastle.crypto.params Ed25519KeyGenerationParameters Ed25519PrivateKeyParameters Ed25519PublicKeyParameters)
            (org.bouncycastle.crypto.signers Ed25519Signer)))
-
-(defn bytes->hex
-  "convert byte array to hex string."
-  [^bytes byte-array]
-  (let [hex [\0 \1 \2 \3 \4 \5 \6 \7 \8 \9 \a \b \c \d \e \f]]
-    (letfn [(hexify-byte [b]
-              (let [v (bit-and b 0xFF)]
-                [(hex (bit-shift-right v 4)) (hex (bit-and v 0x0F))]))]
-      (str/join (mapcat hexify-byte byte-array)))))
-
-(defn hex->bytes
-  "convert hex string to byte array."
-  [^String hex-string]
-  (letfn [(unhexify-2 [^Character c1 ^Character c2]
-            (unchecked-byte
-             (+ (bit-shift-left (Character/digit c1 16) 4)
-                (Character/digit c2 16))))]
-    (byte-array (map #(apply unhexify-2 %) (partition 2 hex-string)))))
 
 (defn generate-keypair
   "generate Ed25519 key pair.
@@ -67,6 +49,6 @@
   "verify discord payload with app public-key,
   request body, signature and timestamp headers"
   [public-key timestamp body signature]
-  (verify (new-verifier (Ed25519PublicKeyParameters. (hex->bytes public-key) 0))
+  (verify (new-verifier (Ed25519PublicKeyParameters. (adapters.bytes/hex->bytes public-key) 0))
           (.getBytes (str timestamp body) "utf8")
-          (hex->bytes signature)))
+          (adapters.bytes/hex->bytes signature)))

--- a/src/super_dice_roll/messages.clj
+++ b/src/super_dice_roll/messages.clj
@@ -6,6 +6,7 @@
   [channel :- schemas.models/Channel]
   (case channel
     :discord "Available commands: `/roll`, `/history` or `/help`\n"
+    :slack "Available commands: `/roll`, `/history` or `/help`\n"
     :telegram "Available commands: <pre>/roll</pre>, <pre>/history</pre> or <pre>/help</pre>\n"))
 
 (s/defn help-roll :- s/Str
@@ -17,6 +18,12 @@
                   "D = Dice type (D6, D12, D20)\n"
                   "M = Modifiers (+1, -3)\n"
                   "Example: `/roll 3D6+3`\n")
+    :slack (str "`/roll <NDM>`\n"
+                "You must specify dice and modifiers in following format:\n"
+                "N = Number of dices\n"
+                "D = Dice type (D6, D12, D20)\n"
+                "M = Modifiers (+1, -3)\n"
+                "Example: `/roll 3D6+3`\n")
     :telegram (str "<pre>/roll &lt;NDM&gt;</pre>\n"
                    "You must specify dice and modifiers in following format:\n"
                    "N = Number of dices\n"
@@ -29,6 +36,8 @@
   (case channel
     :discord (str "`/history`\n"
                   "Lists your lasts 10 rolls with the results.\n")
+    :slack (str "`/history`\n"
+                "Lists your lasts 10 rolls with the results.\n")
     :telegram (str "<pre>/history</pre>\n"
                    "Lists your lasts 10 rolls with the results.\n")))
 
@@ -36,6 +45,7 @@
   [channel :- schemas.models/Channel]
   (case channel
     :discord "[Source Code](https://j.mp/sdr-bot)\n"
+    :slack "<https://j.mp/sdr-bot|Source Code>\n"
     :telegram "<a href=\"https://j.mp/sdr-bot\">Source Code</a>\n"))
 
 (s/defn help :- s/Str

--- a/src/super_dice_roll/routes.clj
+++ b/src/super_dice_roll/routes.clj
@@ -4,6 +4,9 @@
             [super-dice-roll.discord.interceptor :as discord.interceptor]
             [super-dice-roll.discord.ports.http-in :as discord.ports.http-in]
             [super-dice-roll.discord.schemas.http-in :as discord.schemas.http-in]
+            [super-dice-roll.slack.interceptor :as slack.interceptor]
+            [super-dice-roll.slack.ports.http-in :as slack.ports.http-in]
+            [super-dice-roll.slack.schemas.http-in :as slack.schemas.http-in]
             [super-dice-roll.telegram.interceptor :as telegram.interceptor]
             [super-dice-roll.telegram.ports.http-in :as telegram.ports.http-in]
             [super-dice-roll.telegram.schemas.http-in :as telegram.schemas.http-in]))
@@ -29,6 +32,22 @@
                          401 {:body s/Str}
                          500 {:body s/Str}}
              :handler discord.ports.http-in/process-interaction!}}]]
+
+   ["/slack"
+    {:swagger {:tags ["slack"]}
+     :interceptors [(slack.interceptor/authentication-interceptor)]
+     :parameters {:header {:x-slack-signature s/Str
+                           :x-slack-request-timestamp s/Str}}}
+
+    ["/slash/:command"
+     {:post {:summary "Slack we'll send a payload to when the command is invoked."
+             :parameters {:path {:command s/Str}
+                          :body slack.schemas.http-in/Command}
+             :responses {200 {:body s/Any}
+                         400 {:body s/Str}
+                         401 {:body s/Str}
+                         500 {:body s/Str}}
+             :handler slack.ports.http-in/process-command!}}]]
 
    ["/telegram"
     {:swagger {:tags ["telegram"]}

--- a/src/super_dice_roll/routes.clj
+++ b/src/super_dice_roll/routes.clj
@@ -42,7 +42,8 @@
     ["/slash/:command"
      {:post {:summary "Slack we'll send a payload to when the command is invoked."
              :parameters {:path {:command s/Str}
-                          :body slack.schemas.http-in/Command}
+                          :form (s/maybe slack.schemas.http-in/Command)
+                          :body (s/maybe slack.schemas.http-in/Command)}
              :responses {200 {:body s/Any}
                          400 {:body s/Str}
                          401 {:body s/Str}

--- a/src/super_dice_roll/schemas/models.clj
+++ b/src/super_dice_roll/schemas/models.clj
@@ -3,7 +3,8 @@
 
 (def ChannelDefinition
   {:discord  1
-   :telegram 2})
+   :telegram 2
+   :slack    3})
 (def Channel (apply s/enum (keys ChannelDefinition)))
 
 (s/defschema User

--- a/src/super_dice_roll/slack/adapters.clj
+++ b/src/super_dice_roll/slack/adapters.clj
@@ -1,0 +1,18 @@
+(ns super-dice-roll.slack.adapters
+  (:require [clojure.string :as string]
+            [schema.core :as s]
+            [super-dice-roll.schemas.models :as schemas.models]
+            [super-dice-roll.slack.schemas.http-in :as slack.schemas.http-in]))
+
+(s/defn wire-in->user :- schemas.models/User
+  [{:keys [user_id user_name]} :- slack.schemas.http-in/Command]
+  {:id (str user_id)
+   :username (str user_name)
+   :nick ""
+   :channel :slack})
+
+(s/defn wire-in->model :- schemas.models/RollCommand
+  [{:keys [text] :as input} :- slack.schemas.http-in/Command]
+  (let [command (if (not (string/blank? text)) (string/trim text) "")]
+    {:user (wire-in->user input)
+     :command command}))

--- a/src/super_dice_roll/slack/interceptor.clj
+++ b/src/super_dice_roll/slack/interceptor.clj
@@ -1,0 +1,20 @@
+(ns super-dice-roll.slack.interceptor
+  (:require [super-dice-roll.slack.security :as slack.security]))
+
+(defn now-secs [] (quot (System/currentTimeMillis) 1000))
+
+(defn authentication-interceptor []
+  {:name ::validate-request-interaction
+   :enter (fn [ctx]
+            (let [request (:request ctx)
+                  {{:keys [config]} :components} request
+                  now (now-secs)
+                  signing-secret (get-in config [:config :slack :signing-secret])
+                  signature (get-in ctx [:request :headers "x-slack-signature"])
+                  timestamp (get-in ctx [:request :headers "x-slack-request-timestamp"])
+                  raw-body (get ctx :raw-body)]
+              (if (slack.security/verify-request signing-secret now timestamp raw-body signature)
+                ctx
+                (assoc ctx :response {:headers {"Content-Type" "application/text"}
+                                      :status 401
+                                      :body "invalid request signature"}))))})

--- a/src/super_dice_roll/slack/ports/http_in.clj
+++ b/src/super_dice_roll/slack/ports/http_in.clj
@@ -23,9 +23,10 @@
     nil))
 
 (defn process-command!
-  [{{body :body} :parameters
+  [{{body :body form :form} :parameters
     components :components}]
-  (let [message (command->message body components)]
+  (let [payload (or form body)
+        message (command->message payload components)]
     {:status 200
      :body (if message
              {:response_type "in_channel"

--- a/src/super_dice_roll/slack/ports/http_in.clj
+++ b/src/super_dice_roll/slack/ports/http_in.clj
@@ -1,0 +1,33 @@
+(ns super-dice-roll.slack.ports.http-in
+  (:require [schema.core :as s]
+            [super-dice-roll.adapters :as base.adapters]
+            [super-dice-roll.controllers :as base.controller]
+            [super-dice-roll.messages :as messages]
+            [super-dice-roll.schemas.types :as schemas.types]
+            [super-dice-roll.slack.adapters :as slack.adapters]
+            [super-dice-roll.slack.schemas.http-in :as slack.schemas.http-in]))
+
+(s/defn ^:private command->message
+  [{:keys [command] :as body} :- slack.schemas.http-in/Command
+   components :- schemas.types/Components]
+  (case command
+    "/roll"    (let [roll-cmd (slack.adapters/wire-in->model body)
+                     rolled (base.controller/do-roll! roll-cmd components)]
+                 (if rolled
+                   (base.adapters/rolled->message rolled)
+                   (base.adapters/roll-command->error-message roll-cmd)))
+    "/history" (-> (slack.adapters/wire-in->user body)
+                   (base.controller/get-user-command-history components)
+                   base.adapters/user-command-history->message)
+    "/help"    (messages/help :slack)
+    nil))
+
+(defn process-command!
+  [{{body :body} :parameters
+    components :components}]
+  (let [message (command->message body components)]
+    {:status 200
+     :body (if message
+             {:response_type "in_channel"
+              :text message}
+             {})}))

--- a/src/super_dice_roll/slack/schemas/http_in.clj
+++ b/src/super_dice_roll/slack/schemas/http_in.clj
@@ -1,0 +1,19 @@
+(ns super-dice-roll.slack.schemas.http-in
+  (:require [schema.core :as s]))
+
+(s/defschema Command
+  {(s/optional-key :token) s/Str
+   (s/optional-key :team_id) s/Str
+   (s/optional-key :team_domain) s/Str
+   (s/optional-key :enterprise_id) s/Str
+   (s/optional-key :enterprise_name) s/Str
+   (s/optional-key :channel_id) s/Str
+   (s/optional-key :channel_name) s/Str
+   (s/optional-key :user_id) s/Str
+   (s/optional-key :user_name) s/Str
+   (s/optional-key :command) s/Str
+   (s/optional-key :text) s/Str
+   (s/optional-key :response_url) s/Str
+   (s/optional-key :trigger_id) s/Str
+   (s/optional-key :api_app_id) s/Str
+   s/Any s/Any})

--- a/src/super_dice_roll/slack/security.clj
+++ b/src/super_dice_roll/slack/security.clj
@@ -1,0 +1,41 @@
+(ns super-dice-roll.slack.security
+  (:require [clojure.string :as str])
+  (:import [org.bouncycastle.crypto.digests SHA256Digest]
+           [org.bouncycastle.crypto.macs HMac]
+           [org.bouncycastle.crypto.params KeyParameter]))
+
+;; TODO
+;; https://api.slack.com/authentication/verifying-requests-from-slack
+;; https://api.slack.com/interactivity/slash-commands
+
+;; TODO move this to base adapters/byte ns
+(defn bytes->hex
+  "convert byte array to hex string."
+  [^bytes byte-array]
+  (let [hex [\0 \1 \2 \3 \4 \5 \6 \7 \8 \9 \a \b \c \d \e \f]]
+    (letfn [(hexify-byte [b]
+              (let [v (bit-and b 0xFF)]
+                [(hex (bit-shift-right v 4)) (hex (bit-and v 0x0F))]))]
+      (str/join (mapcat hexify-byte byte-array)))))
+
+(defn sign-hmac-sha256
+  "generate HMac SHA256 signature for data and key byte arrays.
+  return byte array with signature."
+  [^String data ^String key]
+  (let [digest (new SHA256Digest)
+        hmac (new HMac digest)
+        data-bytes (.getBytes data "utf8")
+        key-bytes (.getBytes key "utf8")
+        hmac-out (byte-array (.getMacSize hmac))]
+
+    (.init hmac (new KeyParameter key-bytes))
+    (.update hmac data-bytes 0 (alength data-bytes))
+    (.doFinal hmac hmac-out 0)
+    hmac-out))
+
+(comment
+  ;; tests
+  (def slack-signing-secret "8f742231b10e8888abcd99yyyzzz85a5")
+  (def sig-basestring "v0:1531420618:token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c")
+  (= (bytes->hex (sign-hmac-sha256 sig-basestring slack-signing-secret))
+     "a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503"))

--- a/src/super_dice_roll/slack/security.clj
+++ b/src/super_dice_roll/slack/security.clj
@@ -1,24 +1,15 @@
 (ns super-dice-roll.slack.security
-  (:require [clojure.string :as str])
+  (:require [clojure.string :as str]
+            [super-dice-roll.adapters.bytes :as adapters.bytes])
   (:import [org.bouncycastle.crypto.digests SHA256Digest]
            [org.bouncycastle.crypto.macs HMac]
            [org.bouncycastle.crypto.params KeyParameter]))
 
-;; TODO
-;; https://api.slack.com/authentication/verifying-requests-from-slack
-;; https://api.slack.com/interactivity/slash-commands
+(def version "v0")
 
-;; TODO move this to base adapters/byte ns
-(defn bytes->hex
-  "convert byte array to hex string."
-  [^bytes byte-array]
-  (let [hex [\0 \1 \2 \3 \4 \5 \6 \7 \8 \9 \a \b \c \d \e \f]]
-    (letfn [(hexify-byte [b]
-              (let [v (bit-and b 0xFF)]
-                [(hex (bit-shift-right v 4)) (hex (bit-and v 0x0F))]))]
-      (str/join (mapcat hexify-byte byte-array)))))
+(def separator ":")
 
-(defn sign-hmac-sha256
+(defn hash-hmac-sha256
   "generate HMac SHA256 signature for data and key byte arrays.
   return byte array with signature."
   [^String data ^String key]
@@ -33,9 +24,14 @@
     (.doFinal hmac hmac-out 0)
     hmac-out))
 
-(comment
-  ;; tests
-  (def slack-signing-secret "8f742231b10e8888abcd99yyyzzz85a5")
-  (def sig-basestring "v0:1531420618:token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c")
-  (= (bytes->hex (sign-hmac-sha256 sig-basestring slack-signing-secret))
-     "a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503"))
+(defn verify-request
+  "verify slack payload with app signing-secret, request body,
+  signature and timestamp headers.
+  return boolean with verification.
+  https://api.slack.com/authentication/verifying-requests-from-slack"
+  [^String signing-secret ^Number now ^Number timestamp ^String body ^String signature]
+  (let [basestring (str/join separator [version timestamp body])
+        hash (adapters.bytes/bytes->hex (hash-hmac-sha256 basestring signing-secret))]
+    (and
+     (> (* 60 5) (- now timestamp))
+     (= (str version "=" hash) signature))))

--- a/src/super_dice_roll/slack/security.clj
+++ b/src/super_dice_roll/slack/security.clj
@@ -29,9 +29,10 @@
   signature and timestamp headers.
   return boolean with verification.
   https://api.slack.com/authentication/verifying-requests-from-slack"
-  [^String signing-secret ^Number now ^Number timestamp ^String body ^String signature]
-  (let [basestring (str/join separator [version timestamp body])
+  [^String signing-secret ^Number now ^String timestamp ^String body ^String signature]
+  (let [timestamp-number (or (parse-long timestamp) 0)
+        basestring (str/join separator [version timestamp body])
         hash (adapters.bytes/bytes->hex (hash-hmac-sha256 basestring signing-secret))]
     (and
-     (> (* 60 5) (- now timestamp))
+     (> (* 60 5) (- now timestamp-number))
      (= (str version "=" hash) signature))))

--- a/test/integration/super_dice_roll/discord/commands_test.clj
+++ b/test/integration/super_dice_roll/discord/commands_test.clj
@@ -11,6 +11,7 @@
             [state-flow.api :refer [defflow]]
             [state-flow.assertions.matcher-combinators :refer [match?]]
             [state-flow.core :as state-flow :refer [flow]]
+            [super-dice-roll.adapters.bytes :as adapters.bytes]
             [super-dice-roll.components.router :as components.router]
             [super-dice-roll.discord.security :as discord.security]
             [super-dice-roll.messages :as messages]
@@ -23,7 +24,7 @@
     (component/start-system
      (component/system-map
       :config (components.config/new-config
-               {:discord {:app-public-key (discord.security/bytes->hex (.getEncoded (:public key-pair)))
+               {:discord {:app-public-key (adapters.bytes/bytes->hex (.getEncoded (:public key-pair)))
                           :app-test-signer (discord.security/new-signer (:private key-pair))}})
       :http (components.http/new-http-mock {})
       :router (components.router/new-router routes/routes)

--- a/test/integration/super_dice_roll/discord/commands_test.clj
+++ b/test/integration/super_dice_roll/discord/commands_test.clj
@@ -44,39 +44,39 @@
       (match? (matchers/embeds {:status 200
                                 :body  {:type 4
                                         :data {:content (matchers/regex #"papoulos rolled 4d6-1")}}})
-              (util/signed-request! {:method :post
-                                     :uri    "/discord/webhook"
-                                     :body   {:id "discord-id-1"
-                                              :application_id "discord-app-id-1"
-                                              :token "discord-token-1"
-                                              :version 1
-                                              :type 2
-                                              :member {:user {:id "discord-user-id-1"
-                                                              :username "papoulos"}}
-                                              :data {:id "discord-data-id-1"
-                                                     :type 1
-                                                     :name "roll"
-                                                     :options [{:id "discord-data-options-1"
-                                                                :name "command"
-                                                                :type 3
-                                                                :value "4d6-1"}]}}})))
+              (util/discord-signed-request! {:method :post
+                                             :uri    "/discord/webhook"
+                                             :body   {:id "discord-id-1"
+                                                      :application_id "discord-app-id-1"
+                                                      :token "discord-token-1"
+                                                      :version 1
+                                                      :type 2
+                                                      :member {:user {:id "discord-user-id-1"
+                                                                      :username "papoulos"}}
+                                                      :data {:id "discord-data-id-1"
+                                                             :type 1
+                                                             :name "roll"
+                                                             :options [{:id "discord-data-options-1"
+                                                                        :name "command"
+                                                                        :type 3
+                                                                        :value "4d6-1"}]}}})))
 
     (flow "should be able to send a /history command"
       (match? (matchers/embeds {:status 200
                                 :body  {:type 4
                                         :data {:content (matchers/regex #"\*papoulos history\*\n`4d6-1: \[")}}})
-              (util/signed-request! {:method :post
-                                     :uri    "/discord/webhook"
-                                     :body   {:id "discord-id-1"
-                                              :application_id "discord-app-id-1"
-                                              :token "discord-token-1"
-                                              :version 1
-                                              :type 2
-                                              :member {:user {:id "discord-user-id-1"
-                                                              :username "papoulos"}}
-                                              :data {:id "discord-data-id-1"
-                                                     :type 1
-                                                     :name "history"}}})
+              (util/discord-signed-request! {:method :post
+                                             :uri    "/discord/webhook"
+                                             :body   {:id "discord-id-1"
+                                                      :application_id "discord-app-id-1"
+                                                      :token "discord-token-1"
+                                                      :version 1
+                                                      :type 2
+                                                      :member {:user {:id "discord-user-id-1"
+                                                                      :username "papoulos"}}
+                                                      :data {:id "discord-data-id-1"
+                                                             :type 1
+                                                             :name "history"}}})
               {:times-to-try 5
                :sleep-time   200}))
 
@@ -84,15 +84,15 @@
       (match? (matchers/embeds {:status 200
                                 :body  {:type 4
                                         :data {:content (messages/help :discord)}}})
-              (util/signed-request! {:method :post
-                                     :uri    "/discord/webhook"
-                                     :body   {:id "discord-id-1"
-                                              :application_id "discord-app-id-1"
-                                              :token "discord-token-1"
-                                              :version 1
-                                              :type 2
-                                              :member {:user {:id "discord-user-id-1"
-                                                              :username "papoulos"}}
-                                              :data {:id "discord-data-id-1"
-                                                     :type 1
-                                                     :name "help"}}})))))
+              (util/discord-signed-request! {:method :post
+                                             :uri    "/discord/webhook"
+                                             :body   {:id "discord-id-1"
+                                                      :application_id "discord-app-id-1"
+                                                      :token "discord-token-1"
+                                                      :version 1
+                                                      :type 2
+                                                      :member {:user {:id "discord-user-id-1"
+                                                                      :username "papoulos"}}
+                                                      :data {:id "discord-data-id-1"
+                                                             :type 1
+                                                             :name "help"}}})))))

--- a/test/integration/super_dice_roll/discord/security_test.clj
+++ b/test/integration/super_dice_roll/discord/security_test.clj
@@ -12,6 +12,7 @@
             [state-flow.api :refer [defflow]]
             [state-flow.assertions.matcher-combinators :refer [match?]]
             [state-flow.core :as state-flow :refer [flow]]
+            [super-dice-roll.adapters.bytes :as adapters.bytes]
             [super-dice-roll.components.router :as components.router]
             [super-dice-roll.discord.security :as discord.security]
             [super-dice-roll.routes :as routes]))
@@ -23,7 +24,7 @@
     (component/start-system
      (component/system-map
       :config (components.config/new-config
-               {:discord {:app-public-key (discord.security/bytes->hex (.getEncoded (:public key-pair)))
+               {:discord {:app-public-key (adapters.bytes/bytes->hex (.getEncoded (:public key-pair)))
                           :app-test-signer (discord.security/new-signer (:private key-pair))}})
       :http (components.http/new-http-mock {})
       :router (components.router/new-router routes/routes)

--- a/test/integration/super_dice_roll/discord/security_test.clj
+++ b/test/integration/super_dice_roll/discord/security_test.clj
@@ -7,7 +7,6 @@
             [parenthesin.components.db.jdbc-hikari :as components.database]
             [parenthesin.components.http.clj-http :as components.http]
             [parenthesin.components.server.reitit-pedestal-jetty :as components.webserver]
-            [parenthesin.helpers.state-flow.server.pedestal :as state-flow.server]
             [schema.test :as schema.test]
             [state-flow.api :refer [defflow]]
             [state-flow.assertions.matcher-combinators :refer [match?]]
@@ -53,12 +52,12 @@
     (flow "should not be able to send a unsigned request discord"
       (match? (matchers/embeds {:status 401
                                 :body  "invalid request signature"})
-              (state-flow.server/request! {:method :post
-                                           :uri    "/discord/webhook"
-                                           :headers {"x-signature-ed25519" "x"
-                                                     "x-signature-timestamp" "x"}
-                                           :body   {:id "discord-id-2"
-                                                    :application_id "discord-app-id-2"
-                                                    :type 1
-                                                    :token "discord-token-2"
-                                                    :version 1}})))))
+              (util/request! {:method :post
+                              :uri    "/discord/webhook"
+                              :headers {"x-signature-ed25519" "x"
+                                        "x-signature-timestamp" "x"}
+                              :body   {:id "discord-id-2"
+                                       :application_id "discord-app-id-2"
+                                       :type 1
+                                       :token "discord-token-2"
+                                       :version 1}})))))

--- a/test/integration/super_dice_roll/discord/security_test.clj
+++ b/test/integration/super_dice_roll/discord/security_test.clj
@@ -42,13 +42,13 @@
     (flow "should be able to send a signed request"
       (match? (matchers/embeds {:status 200
                                 :body  {:type 1}})
-              (util/signed-request! {:method :post
-                                     :uri    "/discord/webhook"
-                                     :body   {:id "discord-id-1"
-                                              :application_id "discord-app-id-1"
-                                              :type 1
-                                              :token "discord-token-1"
-                                              :version 1}})))
+              (util/discord-signed-request! {:method :post
+                                             :uri    "/discord/webhook"
+                                             :body   {:id "discord-id-1"
+                                                      :application_id "discord-app-id-1"
+                                                      :type 1
+                                                      :token "discord-token-1"
+                                                      :version 1}})))
 
     (flow "should not be able to send a unsigned request discord"
       (match? (matchers/embeds {:status 401

--- a/test/integration/super_dice_roll/slack/commands_test.clj
+++ b/test/integration/super_dice_roll/slack/commands_test.clj
@@ -1,0 +1,72 @@
+(ns integration.super-dice-roll.slack.commands-test
+  (:require [clojure.test :as clojure.test]
+            [com.stuartsierra.component :as component]
+            [integration.super-dice-roll.util :as util]
+            [matcher-combinators.matchers :as matchers]
+            [parenthesin.components.config.aero :as components.config]
+            [parenthesin.components.db.jdbc-hikari :as components.database]
+            [parenthesin.components.http.clj-http :as components.http]
+            [parenthesin.components.server.reitit-pedestal-jetty :as components.webserver]
+            [schema.test :as schema.test]
+            [state-flow.api :refer [defflow]]
+            [state-flow.assertions.matcher-combinators :refer [match?]]
+            [state-flow.core :as state-flow :refer [flow]]
+            [super-dice-roll.components.router :as components.router]
+            [super-dice-roll.messages :as messages]
+            [super-dice-roll.routes :as routes]))
+
+(clojure.test/use-fixtures :once schema.test/validate-schemas)
+
+(defn- create-and-start-components! []
+  (component/start-system
+   (component/system-map
+    :config (components.config/new-config
+             {:slack {:signing-secret "8f742231b10e8888abcd99yyyzzz85a5"}})
+    :http (components.http/new-http-mock {})
+    :router (components.router/new-router routes/routes)
+    :database (component/using (components.database/new-database)
+                               [:config])
+    :webserver (component/using (components.webserver/new-webserver)
+                                [:config :http :router :database]))))
+
+(defflow
+  flow-integration-wallet-test
+  {:init (util/start-system! create-and-start-components!)
+   :cleanup util/stop-system!
+   :fail-fast? true}
+  (flow "should interact with system"
+
+    (flow "should be able to send a /roll command"
+      (match? (matchers/embeds {:status 200
+                                :body  {:response_type "in_channel"
+                                        :text (matchers/regex #"papoulos rolled 4d6-1")}})
+              (util/slack-signed-request! {:method :post
+                                           :uri    "/slack/slash/roll"
+                                           :body   {:user_id "U2147483697"
+                                                    :user_name "papoulos"
+                                                    :command "/roll"
+                                                    :text "4d6-1"}})))
+
+    (flow "should be able to send a /history command"
+      (match? (matchers/embeds {:status 200
+                                :body  {:response_type "in_channel"
+                                        :text (matchers/regex #"\*papoulos history\*\n`4d6-1: \[")}})
+              (util/slack-signed-request! {:method :post
+                                           :uri    "/slack/slash/history"
+                                           :body   {:user_id "U2147483697"
+                                                    :user_name "papoulos"
+                                                    :command "/history"
+                                                    :text ""}})
+              {:times-to-try 5
+               :sleep-time   200}))
+
+    (flow "should be able to send a /help command"
+      (match? (matchers/embeds {:status 200
+                                :body  {:response_type "in_channel"
+                                        :text (messages/help :slack)}})
+              (util/slack-signed-request! {:method :post
+                                           :uri    "/slack/slash/help"
+                                           :body   {:user_id "U2147483697"
+                                                    :user_name "papoulos"
+                                                    :command "/help"
+                                                    :text ""}})))))

--- a/test/integration/super_dice_roll/slack/security_test.clj
+++ b/test/integration/super_dice_roll/slack/security_test.clj
@@ -1,0 +1,67 @@
+(ns integration.super-dice-roll.slack.security-test
+  (:require [clojure.test :as clojure.test]
+            [com.stuartsierra.component :as component]
+            [integration.super-dice-roll.util :as util]
+            [matcher-combinators.matchers :as matchers]
+            [parenthesin.components.config.aero :as components.config]
+            [parenthesin.components.db.jdbc-hikari :as components.database]
+            [parenthesin.components.http.clj-http :as components.http]
+            [parenthesin.components.server.reitit-pedestal-jetty :as components.webserver]
+            [schema.test :as schema.test]
+            [state-flow.api :refer [defflow]]
+            [state-flow.assertions.matcher-combinators :refer [match?]]
+            [state-flow.core :as state-flow :refer [flow]]
+            [super-dice-roll.components.router :as components.router]
+            [super-dice-roll.routes :as routes]))
+
+(clojure.test/use-fixtures :once schema.test/validate-schemas)
+
+(defn- create-and-start-components! []
+  (component/start-system
+   (component/system-map
+    :config (components.config/new-config
+             {:slack {:signing-secret "8f742231b10e8888abcd99yyyzzz85a5"}})
+    :http (components.http/new-http-mock {})
+    :router (components.router/new-router routes/routes)
+    :database (component/using (components.database/new-database)
+                               [:config])
+    :webserver (component/using (components.webserver/new-webserver)
+                                [:config :http :router :database]))))
+
+(def body-payload {:token "gIkuvaNzQIHg97ATvDxqgjtO"
+                   :team_id "T0001"
+                   :team_domain "example"
+                   :enterprise_id "E0001"
+                   :enterprise_name "Globular%20Construct%20Inc"
+                   :channel_id "C2147483705"
+                   :channel_name "test"
+                   :user_id "U2147483697"
+                   :user_name "Steve"
+                   :command "/help"
+                   :text ""
+                   :response_url "https://hooks.slack.com/commands/1234/5678"
+                   :trigger_id "13345224609.738474920.8088930838d88f008e0"
+                   :api_app_id "A123456"})
+
+(defflow
+  flow-integration-wallet-test
+  {:init (util/start-system! create-and-start-components!)
+   :cleanup util/stop-system!
+   :fail-fast? true}
+  (flow "should interact with system as slack"
+    (flow "should be able to send a signed request"
+      (match? (matchers/embeds {:status 200
+                                :body  {:response_type "in_channel"
+                                        :text "Available commands: `/roll`, `/history` or `/help`\n\n`/roll <NDM>`\nYou must specify dice and modifiers in following format:\nN = Number of dices\nD = Dice type (D6, D12, D20)\nM = Modifiers (+1, -3)\nExample: `/roll 3D6+3`\n\n`/history`\nLists your lasts 10 rolls with the results.\n\n<https://j.mp/sdr-bot|Source Code>\n"}})
+              (util/slack-signed-request! {:method :post
+                                           :uri    "/slack/slash/help"
+                                           :body   body-payload})))
+
+    (flow "should not be able to send a unsigned request slack"
+      (match? (matchers/embeds {:status 401
+                                :body  "invalid request signature"})
+              (util/request! {:method :post
+                              :uri    "/slack/slash/roll"
+                              :headers {"x-slack-signature" "x"
+                                        "x-slack-request-timestamp" "x"}
+                              :body   body-payload})))))

--- a/test/integration/super_dice_roll/telegram/commands_test.clj
+++ b/test/integration/super_dice_roll/telegram/commands_test.clj
@@ -8,7 +8,6 @@
             [parenthesin.components.http.clj-http :as components.http]
             [parenthesin.components.server.reitit-pedestal-jetty :as components.webserver]
             [parenthesin.helpers.state-flow.http :as state-flow.http]
-            [parenthesin.helpers.state-flow.server.pedestal :as state-flow.server]
             [schema.test :as schema.test]
             [state-flow.api :refer [defflow]]
             [state-flow.assertions.matcher-combinators :refer [match?]]
@@ -44,49 +43,49 @@
 
     (flow "should not error on nil"
       (match? (matchers/embeds {:status 200})
-              (state-flow.server/request! {:method :post
-                                           :uri    (str "/telegram/webhook/" telegram-bot-token)
-                                           :body   {:update_id 987654321
-                                                    :message {:date 1626904234
-                                                              :entities [{:offset 0
-                                                                          :type "bot_command"
-                                                                          :length 5}]
-                                                              :chat {:first_name "Schua"
-                                                                     :username "schuazeneger"
-                                                                     :type "private"
-                                                                     :id 111
-                                                                     :last_name "Zeneger"}
-                                                              :message_id 1
-                                                              :from {:first_name "Schua"
-                                                                     :language_code "en"
-                                                                     :is_bot false
-                                                                     :username "schuazeneger"
-                                                                     :id 12345678
-                                                                     :last_name "Zeneger"}
-                                                              :text nil}}})))
+              (util/request! {:method :post
+                              :uri    (str "/telegram/webhook/" telegram-bot-token)
+                              :body   {:update_id 987654321
+                                       :message {:date 1626904234
+                                                 :entities [{:offset 0
+                                                             :type "bot_command"
+                                                             :length 5}]
+                                                 :chat {:first_name "Schua"
+                                                        :username "schuazeneger"
+                                                        :type "private"
+                                                        :id 111
+                                                        :last_name "Zeneger"}
+                                                 :message_id 1
+                                                 :from {:first_name "Schua"
+                                                        :language_code "en"
+                                                        :is_bot false
+                                                        :username "schuazeneger"
+                                                        :id 12345678
+                                                        :last_name "Zeneger"}
+                                                 :text nil}}})))
 
     (flow "should ignore any other text"
       (match? (matchers/embeds {:status 200})
-              (state-flow.server/request! {:method :post
-                                           :uri    (str "/telegram/webhook/" telegram-bot-token)
-                                           :body   {:update_id 987654321
-                                                    :message {:date 1626904234
-                                                              :entities [{:offset 0
-                                                                          :type "bot_command"
-                                                                          :length 5}]
-                                                              :chat {:first_name "Schua"
-                                                                     :username "schuazeneger"
-                                                                     :type "private"
-                                                                     :id 111
-                                                                     :last_name "Zeneger"}
-                                                              :message_id 1
-                                                              :from {:first_name "Schua"
-                                                                     :language_code "en"
-                                                                     :is_bot false
-                                                                     :username "schuazeneger"
-                                                                     :id 12345678
-                                                                     :last_name "Zeneger"}
-                                                              :text "blabla"}}})))
+              (util/request! {:method :post
+                              :uri    (str "/telegram/webhook/" telegram-bot-token)
+                              :body   {:update_id 987654321
+                                       :message {:date 1626904234
+                                                 :entities [{:offset 0
+                                                             :type "bot_command"
+                                                             :length 5}]
+                                                 :chat {:first_name "Schua"
+                                                        :username "schuazeneger"
+                                                        :type "private"
+                                                        :id 111
+                                                        :last_name "Zeneger"}
+                                                 :message_id 1
+                                                 :from {:first_name "Schua"
+                                                        :language_code "en"
+                                                        :is_bot false
+                                                        :username "schuazeneger"
+                                                        :id 12345678
+                                                        :last_name "Zeneger"}
+                                                 :text "blabla"}}})))
 
     (flow "should NOT send message to telegram api"
       (match? 0
@@ -97,26 +96,26 @@
 
     (flow "should be able to send a /roll command"
       (match? (matchers/embeds {:status 200})
-              (state-flow.server/request! {:method :post
-                                           :uri    (str "/telegram/webhook/" telegram-bot-token)
-                                           :body   {:update_id 987654321
-                                                    :message {:date 1626904234
-                                                              :entities [{:offset 0
-                                                                          :type "bot_command"
-                                                                          :length 5}]
-                                                              :chat {:first_name "Schua"
-                                                                     :username "schuazeneger"
-                                                                     :type "private"
-                                                                     :id 111
-                                                                     :last_name "Zeneger"}
-                                                              :message_id 1
-                                                              :from {:first_name "Schua"
-                                                                     :language_code "en"
-                                                                     :is_bot false
-                                                                     :username "schuazeneger"
-                                                                     :id 12345678
-                                                                     :last_name "Zeneger"}
-                                                              :text "/roll 4d6-1"}}})))
+              (util/request! {:method :post
+                              :uri    (str "/telegram/webhook/" telegram-bot-token)
+                              :body   {:update_id 987654321
+                                       :message {:date 1626904234
+                                                 :entities [{:offset 0
+                                                             :type "bot_command"
+                                                             :length 5}]
+                                                 :chat {:first_name "Schua"
+                                                        :username "schuazeneger"
+                                                        :type "private"
+                                                        :id 111
+                                                        :last_name "Zeneger"}
+                                                 :message_id 1
+                                                 :from {:first_name "Schua"
+                                                        :language_code "en"
+                                                        :is_bot false
+                                                        :username "schuazeneger"
+                                                        :id 12345678
+                                                        :last_name "Zeneger"}
+                                                 :text "/roll 4d6-1"}}})))
 
     (flow "should send message to telegram api with /roll results"
       (match? {:chat_id 111
@@ -131,26 +130,26 @@
 
     (flow "should be able to send a /history command"
       (match? (matchers/embeds {:status 200})
-              (state-flow.server/request! {:method :post
-                                           :uri    (str "/telegram/webhook/" telegram-bot-token)
-                                           :body   {:update_id 987654321
-                                                    :message {:date 1626904234
-                                                              :entities [{:offset 0
-                                                                          :type "bot_command"
-                                                                          :length 5}]
-                                                              :chat {:first_name "Schua"
-                                                                     :username "schuazeneger"
-                                                                     :type "private"
-                                                                     :id 222
-                                                                     :last_name "Zeneger"}
-                                                              :message_id 1
-                                                              :from {:first_name "Schua"
-                                                                     :language_code "en"
-                                                                     :is_bot false
-                                                                     :username "schuazeneger"
-                                                                     :id 12345678
-                                                                     :last_name "Zeneger"}
-                                                              :text "/history"}}})))
+              (util/request! {:method :post
+                              :uri    (str "/telegram/webhook/" telegram-bot-token)
+                              :body   {:update_id 987654321
+                                       :message {:date 1626904234
+                                                 :entities [{:offset 0
+                                                             :type "bot_command"
+                                                             :length 5}]
+                                                 :chat {:first_name "Schua"
+                                                        :username "schuazeneger"
+                                                        :type "private"
+                                                        :id 222
+                                                        :last_name "Zeneger"}
+                                                 :message_id 1
+                                                 :from {:first_name "Schua"
+                                                        :language_code "en"
+                                                        :is_bot false
+                                                        :username "schuazeneger"
+                                                        :id 12345678
+                                                        :last_name "Zeneger"}
+                                                 :text "/history"}}})))
 
     (flow "should send message to telegram api with /history results"
       (match? {:chat_id 222
@@ -167,26 +166,26 @@
 
     (flow "should be able to send a /help command"
       (match? (matchers/embeds {:status 200})
-              (state-flow.server/request! {:method :post
-                                           :uri    (str "/telegram/webhook/" telegram-bot-token)
-                                           :body   {:update_id 987654321
-                                                    :message {:date 1626904234
-                                                              :entities [{:offset 0
-                                                                          :type "bot_command"
-                                                                          :length 5}]
-                                                              :chat {:first_name "Schua"
-                                                                     :username "schuazeneger"
-                                                                     :type "private"
-                                                                     :id 333
-                                                                     :last_name "Zeneger"}
-                                                              :message_id 1
-                                                              :from {:first_name "Schua"
-                                                                     :language_code "en"
-                                                                     :is_bot false
-                                                                     :username "schuazeneger"
-                                                                     :id 12345678
-                                                                     :last_name "Zeneger"}
-                                                              :text "/help"}}})))
+              (util/request! {:method :post
+                              :uri    (str "/telegram/webhook/" telegram-bot-token)
+                              :body   {:update_id 987654321
+                                       :message {:date 1626904234
+                                                 :entities [{:offset 0
+                                                             :type "bot_command"
+                                                             :length 5}]
+                                                 :chat {:first_name "Schua"
+                                                        :username "schuazeneger"
+                                                        :type "private"
+                                                        :id 333
+                                                        :last_name "Zeneger"}
+                                                 :message_id 1
+                                                 :from {:first_name "Schua"
+                                                        :language_code "en"
+                                                        :is_bot false
+                                                        :username "schuazeneger"
+                                                        :id 12345678
+                                                        :last_name "Zeneger"}
+                                                 :text "/help"}}})))
 
     (flow "should send message to telegram api with /help results"
       (match? {:chat_id 333

--- a/test/integration/super_dice_roll/telegram/security_test.clj
+++ b/test/integration/super_dice_roll/telegram/security_test.clj
@@ -7,7 +7,6 @@
             [parenthesin.components.db.jdbc-hikari :as components.database]
             [parenthesin.components.http.clj-http :as components.http]
             [parenthesin.components.server.reitit-pedestal-jetty :as components.webserver]
-            [parenthesin.helpers.state-flow.server.pedestal :as state-flow.server]
             [schema.test :as schema.test]
             [state-flow.api :refer [defflow]]
             [state-flow.assertions.matcher-combinators :refer [match?]]
@@ -60,13 +59,13 @@
 
     (flow "should be able to send a signed request"
       (match? (matchers/embeds {:status 200})
-              (state-flow.server/request! {:method :post
-                                           :uri    (str "/telegram/webhook/" telegram-bot-token)
-                                           :body   request-body})))
+              (util/request! {:method :post
+                              :uri    (str "/telegram/webhook/" telegram-bot-token)
+                              :body   request-body})))
 
     (flow "should not be able to send a unsigned request"
       (match? (matchers/embeds {:status 401
                                 :body  "invalid bot-token sent"})
-              (state-flow.server/request! {:method :post
-                                           :uri    "/telegram/webhook/very-wrong-token"
-                                           :body   request-body})))))
+              (util/request! {:method :post
+                              :uri    "/telegram/webhook/very-wrong-token"
+                              :body   request-body})))))

--- a/test/integration/super_dice_roll/util.clj
+++ b/test/integration/super_dice_roll/util.clj
@@ -10,9 +10,9 @@
             [super-dice-roll.adapters.bytes :as adapters.bytes]
             [super-dice-roll.discord.security :as discord.security]))
 
-(defn signed-request!
+(defn discord-signed-request!
   [{:keys [body] :as request}]
-  (flow "makes http request"
+  (flow "makes discord signed http request"
     [signer (state-flow.api/get-state (comp :app-test-signer :discord :config :config))
      :let [timestamp (str (quot (System/currentTimeMillis) 1000))
            signature (->> (str timestamp (json/encode body))

--- a/test/integration/super_dice_roll/util.clj
+++ b/test/integration/super_dice_roll/util.clj
@@ -7,6 +7,7 @@
             [pg-embedded-clj.core :as pg-emb]
             [state-flow.api :as state-flow.api]
             [state-flow.core :as state-flow :refer [flow]]
+            [super-dice-roll.adapters.bytes :as adapters.bytes]
             [super-dice-roll.discord.security :as discord.security]))
 
 (defn signed-request!
@@ -17,7 +18,7 @@
            signature (->> (str timestamp (json/encode body))
                           .getBytes
                           (discord.security/sign signer)
-                          discord.security/bytes->hex)]]
+                          adapters.bytes/bytes->hex)]]
     (state-flow.server/request! (-> request
                                     (assoc-in [:headers "x-signature-ed25519"] signature)
                                     (assoc-in [:headers "x-signature-timestamp"] timestamp)))))

--- a/test/integration/super_dice_roll/util.clj
+++ b/test/integration/super_dice_roll/util.clj
@@ -1,14 +1,19 @@
 (ns integration.super-dice-roll.util
   (:require [cheshire.core :as json]
+            [clojure.string :as string]
             [com.stuartsierra.component :as component]
             [parenthesin.helpers.logs :as logs]
             [parenthesin.helpers.migrations :as migrations]
             [parenthesin.helpers.state-flow.server.pedestal :as state-flow.server]
             [pg-embedded-clj.core :as pg-emb]
+            [ring.util.codec :as codec]
             [state-flow.api :as state-flow.api]
             [state-flow.core :as state-flow :refer [flow]]
             [super-dice-roll.adapters.bytes :as adapters.bytes]
-            [super-dice-roll.discord.security :as discord.security]))
+            [super-dice-roll.discord.security :as discord.security]
+            [super-dice-roll.slack.security :as slack.security]))
+
+(defn request! [args] (state-flow.server/request! args))
 
 (defn discord-signed-request!
   [{:keys [body] :as request}]
@@ -19,9 +24,23 @@
                           .getBytes
                           (discord.security/sign signer)
                           adapters.bytes/bytes->hex)]]
-    (state-flow.server/request! (-> request
-                                    (assoc-in [:headers "x-signature-ed25519"] signature)
-                                    (assoc-in [:headers "x-signature-timestamp"] timestamp)))))
+    (request! (-> request
+                  (assoc-in [:headers "x-signature-ed25519"] signature)
+                  (assoc-in [:headers "x-signature-timestamp"] timestamp)))))
+
+(defn slack-signed-request!
+  [{:keys [body] :as request}]
+  (flow "makes discord signed http request"
+    [signing-secret (state-flow.api/get-state (comp :signing-secret :slack :config :config))
+     :let [timestamp (str (quot (System/currentTimeMillis) 1000))
+           basestring (slack.security/hash-hmac-sha256
+                       (string/join ":" [slack.security/version timestamp (codec/form-encode body)])
+                       signing-secret)
+           signature (str slack.security/version "=" (adapters.bytes/bytes->hex basestring))]]
+    (request! (-> request
+                  (assoc-in [:headers "Content-Type"] "application/x-www-form-urlencoded")
+                  (assoc-in [:headers "x-slack-signature"] signature)
+                  (assoc-in [:headers "x-slack-request-timestamp"] timestamp)))))
 
 (defn start-system!
   [system-start-fn]

--- a/test/unit/super_dice_roll/adapters/bytes_test.clj
+++ b/test/unit/super_dice_roll/adapters/bytes_test.clj
@@ -1,0 +1,16 @@
+(ns unit.super-dice-roll.adapters.bytes-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [schema.test :as schema.test]
+            [super-dice-roll.adapters.bytes :as adapter.bytes]))
+
+(use-fixtures :once schema.test/validate-schemas)
+
+(deftest hex->bytes-test
+  (testing "should convert to byte array"
+    (is (= (seq [115 108 97 99 107 98 111 116])
+           (seq (adapter.bytes/hex->bytes "736c61636b626f74"))))))
+
+(deftest bytes->hex-test
+  (testing "should convert to byte array"
+    (is (= "736c61636b626f74"
+           (adapter.bytes/bytes->hex [115 108 97 99 107 98 111 116])))))

--- a/test/unit/super_dice_roll/discord/interceptor_test.clj
+++ b/test/unit/super_dice_roll/discord/interceptor_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [matcher-combinators.test :refer [match?]]
             [schema.test :as schema.test]
+            [super-dice-roll.adapters.bytes :as adapters.bytes]
             [super-dice-roll.discord.interceptor :as discord.interceptor]
             [super-dice-roll.discord.security :as discord.security]))
 
@@ -18,10 +19,10 @@
 (deftest verify-request-test
   (let [key-pair (discord.security/generate-keypair)
         signer (discord.security/new-signer (:private key-pair))
-        public-key-hex (discord.security/bytes->hex (.getEncoded (:public key-pair)))
+        public-key-hex (adapters.bytes/bytes->hex (.getEncoded (:public key-pair)))
         timestamp "1625603592"
         body "this should be a json."
-        signature (->> (str timestamp body) .getBytes (discord.security/sign signer) discord.security/bytes->hex)]
+        signature (->> (str timestamp body) .getBytes (discord.security/sign signer) adapters.bytes/bytes->hex)]
     (testing "interceptor should check signature vs public-key, timestamp and body"
       (is (match? {:response {:status 200}}
                   (interceptor-fn (build-ctx public-key-hex

--- a/test/unit/super_dice_roll/discord/security_test.clj
+++ b/test/unit/super_dice_roll/discord/security_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [matcher-combinators.test :refer [match?]]
             [schema.test :as schema.test]
+            [super-dice-roll.adapters.bytes :as adapters.bytes]
             [super-dice-roll.discord.security :as discord.security]))
 
 (use-fixtures :once schema.test/validate-schemas)
@@ -9,10 +10,10 @@
 (deftest verify-request-test
   (let [key-pair (discord.security/generate-keypair)
         signer (discord.security/new-signer (:private key-pair))
-        public-key-hex (discord.security/bytes->hex (.getEncoded (:public key-pair)))
+        public-key-hex (adapters.bytes/bytes->hex (.getEncoded (:public key-pair)))
         timestamp "1625603592"
         body "this should be a json."
-        signature (->> (str timestamp body) .getBytes (discord.security/sign signer) discord.security/bytes->hex)]
+        signature (->> (str timestamp body) .getBytes (discord.security/sign signer) adapters.bytes/bytes->hex)]
     (testing "verify-request should check signature vs public-key, timestamp and body"
       (is (match? true
                   (discord.security/verify-request public-key-hex

--- a/test/unit/super_dice_roll/slack/adapters_test.clj
+++ b/test/unit/super_dice_roll/slack/adapters_test.clj
@@ -1,0 +1,45 @@
+(ns unit.super-dice-roll.slack.adapters-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [matcher-combinators.test :refer [match?]]
+            [schema.test :as schema.test]
+            [super-dice-roll.slack.adapters :as adapters]))
+
+(use-fixtures :once schema.test/validate-schemas)
+
+(def update-msg-1
+  {:token "gIkuvaNzQIHg97ATvDxqgjtO"
+   :team_id "T0001"
+   :team_domain "example"
+   :enterprise_id "E0001"
+   :enterprise_name "Globular%20Construct%20Inc"
+   :channel_id "C2147483705"
+   :channel_name "test"
+   :user_id "U2147483697"
+   :user_name "Steve"
+   :command "/roll"
+   :text "6d4+5"
+   :response_url "https://hooks.slack.com/commands/1234/5678"
+   :trigger_id "13345224609.738474920.8088930838d88f008e0"
+   :api_app_id "A123456"})
+
+(deftest wire-in->user-test
+  (testing "should get the current user"
+    (is (match? {:id "U2147483697"
+                 :username "Steve"
+                 :nick ""}
+                (adapters/wire-in->user update-msg-1)))))
+
+(deftest wire-in->model-test
+  (testing "should adapt update into roll"
+    (is (match? {:user {:id "U2147483697"
+                        :username "Steve"
+                        :nick ""}
+                 :command "6d4+5"}
+                (adapters/wire-in->model update-msg-1))))
+
+  (testing "should adapt empty rolls"
+    (is (match? {:user {:id "U2147483697"
+                        :username "Steve"
+                        :nick ""}
+                 :command ""}
+                (adapters/wire-in->model (dissoc update-msg-1 :text))))))

--- a/test/unit/super_dice_roll/slack/interceptor_test.clj
+++ b/test/unit/super_dice_roll/slack/interceptor_test.clj
@@ -25,20 +25,20 @@
       (with-redefs [slack.interceptor/now-secs (fn [] timestamp+one-min)]
         (is (match? {:response {:status 200}}
                     (interceptor-fn (build-ctx slack-signing-secret
-                                               timestamp
+                                               (str timestamp)
                                                body
                                                signature)))))
 
       (with-redefs [slack.interceptor/now-secs (fn [] timestamp+six-mins)]
         (is (match? {:response {:status 401}}
                     (interceptor-fn (build-ctx slack-signing-secret
-                                               timestamp
+                                               (str timestamp)
                                                body
                                                signature)))))
 
       (with-redefs [slack.interceptor/now-secs (fn [] timestamp+one-min)]
         (is (match? {:response {:status 401}}
                     (interceptor-fn (build-ctx slack-signing-secret
-                                               timestamp
+                                               (str timestamp)
                                                (str body "hackedbody")
                                                signature))))))))

--- a/test/unit/super_dice_roll/slack/interceptor_test.clj
+++ b/test/unit/super_dice_roll/slack/interceptor_test.clj
@@ -1,0 +1,44 @@
+(ns unit.super-dice-roll.slack.interceptor-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [matcher-combinators.test :refer [match?]]
+            [schema.test :as schema.test]
+            [super-dice-roll.slack.interceptor :as slack.interceptor]))
+
+(use-fixtures :once schema.test/validate-schemas)
+
+(def interceptor-fn (-> (slack.interceptor/authentication-interceptor) :enter))
+(defn build-ctx [signing-secret timestamp body signature]
+  {:response {:status 200}
+   :request {:components {:config {:config {:slack {:signing-secret signing-secret}}}}
+             :headers {"x-slack-signature" signature
+                       "x-slack-request-timestamp" timestamp}}
+   :raw-body body})
+
+(deftest verify-request-test
+  (let [slack-signing-secret "8f742231b10e8888abcd99yyyzzz85a5"
+        timestamp 1531420618
+        timestamp+one-min (+ timestamp (* 60 1))
+        timestamp+six-mins (+ timestamp (* 60 6))
+        body "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"
+        signature "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503"]
+    (testing "interceptor should check signature vs public-key, timestamp and body"
+      (with-redefs [slack.interceptor/now-secs (fn [] timestamp+one-min)]
+        (is (match? {:response {:status 200}}
+                    (interceptor-fn (build-ctx slack-signing-secret
+                                               timestamp
+                                               body
+                                               signature)))))
+
+      (with-redefs [slack.interceptor/now-secs (fn [] timestamp+six-mins)]
+        (is (match? {:response {:status 401}}
+                    (interceptor-fn (build-ctx slack-signing-secret
+                                               timestamp
+                                               body
+                                               signature)))))
+
+      (with-redefs [slack.interceptor/now-secs (fn [] timestamp+one-min)]
+        (is (match? {:response {:status 401}}
+                    (interceptor-fn (build-ctx slack-signing-secret
+                                               timestamp
+                                               (str body "hackedbody")
+                                               signature))))))))

--- a/test/unit/super_dice_roll/slack/security_test.clj
+++ b/test/unit/super_dice_roll/slack/security_test.clj
@@ -17,18 +17,18 @@
       (is (match? true
                   (slack.security/verify-request slack-signing-secret
                                                  timestamp+one-min
-                                                 timestamp
+                                                 (str timestamp)
                                                  body
                                                  signature)))
       (is (match? false
                   (slack.security/verify-request slack-signing-secret
                                                  timestamp+six-mins
-                                                 timestamp
+                                                 (str timestamp)
                                                  body
                                                  signature)))
       (is (match? false
                   (slack.security/verify-request slack-signing-secret
                                                  timestamp+one-min
-                                                 timestamp
+                                                 (str timestamp)
                                                  (str body ".hacks")
                                                  signature))))))

--- a/test/unit/super_dice_roll/slack/security_test.clj
+++ b/test/unit/super_dice_roll/slack/security_test.clj
@@ -1,0 +1,34 @@
+(ns unit.super-dice-roll.slack.security-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [matcher-combinators.test :refer [match?]]
+            [schema.test :as schema.test]
+            [super-dice-roll.slack.security :as slack.security]))
+
+(use-fixtures :once schema.test/validate-schemas)
+
+(deftest verify-request-test
+  (let [slack-signing-secret "8f742231b10e8888abcd99yyyzzz85a5"
+        timestamp 1531420618
+        timestamp+one-min (+ timestamp (* 60 1))
+        timestamp+six-mins (+ timestamp (* 60 6))
+        body "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"
+        signature "v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503"]
+    (testing "verify-request should check signature vs public-key, timestamp and body"
+      (is (match? true
+                  (slack.security/verify-request slack-signing-secret
+                                                 timestamp+one-min
+                                                 timestamp
+                                                 body
+                                                 signature)))
+      (is (match? false
+                  (slack.security/verify-request slack-signing-secret
+                                                 timestamp+six-mins
+                                                 timestamp
+                                                 body
+                                                 signature)))
+      (is (match? false
+                  (slack.security/verify-request slack-signing-secret
+                                                 timestamp+one-min
+                                                 timestamp
+                                                 (str body ".hacks")
+                                                 signature))))))

--- a/tests.edn
+++ b/tests.edn
@@ -2,5 +2,4 @@
  {:tests   [{:id         :unit
              :test-paths ["test/unit"]}
             {:id         :integration
-             :test-paths ["test/integration"]}]
-  :reporter kaocha.report/tap}
+             :test-paths ["test/integration"]}]}


### PR DESCRIPTION
# TODO
- [x] https://api.slack.com/authentication/verifying-requests-from-slack
- [x] https://api.slack.com/interactivity/slash-commands
- [x] Internal routing / parsing
- [x] Adapt wire-in and push to dice logic
- [x] Adapt wire-out and return resulting request